### PR TITLE
Set path to Eclipse workspace which should be used.

### DIFF
--- a/CONFIG
+++ b/CONFIG
@@ -46,20 +46,7 @@ DBUS_EMF_UPDATE_SERVER="http://dbus-emf-model.eclipselabs.org.codespot.com/git/u
 DBUS_EMF_UPDATE_SITE_URL="$DBUS_EMF_UPDATE_SERVER/$DBUS_EMF_VERSION"
 DBUS_EMF_FEATURES=model.emf.dbusxml.feature.feature.group
 
-# GEF 4 -------------------------------------------------------------
-
-# Note: If _VERSION is not set, no particular version will be requested
-# (So Eclipse will install the latest, probably)
-# To specify a specific version, define a variable like this:
-# GEF4_VERSION=0.1.0.201311151505
-# and then:
-# GEF4_FEATURES = org.eclipse.gef4.zest.core/$GEF4_VERSION,  and so on
-# Specifying version of zest.core was required for Franca 0.8.11 but did
-# not work for 0.9.0, and probably no longer needed
-GEF4_UPDATE_SITE_URL="http://download.eclipse.org/tools/gef/gef4/updates/integration"
-GEF4_FEATURES=\
-org.eclipse.gef4.zest.layouts,\
-org.eclipse.gef4.zest.core
+# KIELER framework -------------------------------------------------------------
 
 # Kieler Pragmatics "krendering" package - a new dependency for franca.ui
 # starting with franca release 0.9.2

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,7 +60,7 @@ Type=Application
 Name=Eclipse with Franca
 Name[en_US]=Eclipse with Franca
 Icon=/home/vagrant/tools/autoeclipse/eclipse/icon.xpm
-Exec=/home/vagrant/tools/autoeclipse/eclipse/eclipse
+Exec=/home/vagrant/tools/autoeclipse/eclipse/eclipse -data /home/vagrant/workspace
 EOT
 
 chmod 755 $shortcut

--- a/script.sh
+++ b/script.sh
@@ -257,9 +257,6 @@ check_site_hash           DBUS_EMF
 check_site_latest_version DBUS_EMF
 install_update_site       DBUS_EMF
 
-step "Installing GEF4 from update site"
-install_update_site       GEF4
-
 step "Installing Kieler rendering library required by franca.ui"
 install_update_site       KRENDERING
 


### PR DESCRIPTION
Add a parameter for the desktop icon to choose the proper workspace. This avoids that the user is asked to select a workspace on startup of Eclipse.

This solves https://github.com/gunnarx/franca_install_automation/issues/4.
