### PR TITLE
Support using Luna or Mars release of Eclipse.

### DIFF
--- a/CONFIG
+++ b/CONFIG
@@ -23,22 +23,38 @@ WORKSPACE_DIR=$HOME/workspace
 # be reset to /vagrant instead
 DOWNLOAD_DIR=/tmp
 
+
+# Eclipse distribution ---------------------------------------------------
+
 # URLs to latest x86 32 and 64 bit releases of Eclipse (DSL variant) follow.
 # You can update the one you need...  
 
 # It is recommended to look up and specify your closest mirror URL
-# Choose appropriate mirror using:
-# http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/luna/SR2/eclipse-dsl-luna-SR2-linux-gtk-x86_64.tar.gz
+# Choose appropriate mirror using one of:
+ECLIPSE_ORG="http://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads"
+ECLIPSE_MIRROR_FAU_DE="http://ftp.fau.de/eclipse/technology/epp/downloads"
 
-# NOTE: You can set _MD5 variables to empty to skip MD5 check (just remove the
-# assignment altogether).
+USE_ECLIPSE_MIRROR=$ECLIPSE_MIRROR_FAU_DE
 
-# ! Please consider setting the URL to a mirror near you instead !
-ECLIPSE_INSTALLER_i686="http://ftp.fau.de/eclipse/technology/epp/downloads/release/luna/SR2/eclipse-dsl-luna-SR2-linux-gtk.tar.gz"
-ECLIPSE_MD5_x686=a652ca17a2cb17091eb1bb1e5d7ab25e
+# select Eclipse distribution (one of [luna, mars])
+ECLIPSE_DISTRO=luna
 
-ECLIPSE_INSTALLER_x86_64="http://ftp.fau.de/eclipse/technology/epp/downloads/release/luna/SR2/eclipse-dsl-luna-SR2-linux-gtk-x86_64.tar.gz"
-ECLIPSE_MD5_x86_64=98eeaea78478ac384667e3f05142effc
+# NOTE: You can set _MD5 variables to empty to skip MD5 check (just remove the assignment altogether).
+if [ "x$ECLIPSE_DISTRO" = "xluna" ]
+then
+    ECLIPSE_INSTALLER_i686="$USE_ECLIPSE_MIRROR/release/luna/SR2/eclipse-dsl-luna-SR2-linux-gtk.tar.gz"
+    ECLIPSE_MD5_x686=a652ca17a2cb17091eb1bb1e5d7ab25e
+
+    ECLIPSE_INSTALLER_x86_64="$USE_ECLIPSE_MIRROR/release/luna/SR2/eclipse-dsl-luna-SR2-linux-gtk-x86_64.tar.gz"
+    ECLIPSE_MD5_x86_64=98eeaea78478ac384667e3f05142effc
+else
+    ECLIPSE_INSTALLER_i686="$USE_ECLIPSE_MIRROR/release/mars/R/eclipse-dsl-mars-R-linux-gtk.tar.gz"
+    ECLIPSE_MD5_x686=80c4e3d0dbe204fbf476de08df0fcf18
+
+    ECLIPSE_INSTALLER_x86_64="$USE_ECLIPSE_MIRROR/release/mars/R/eclipse-dsl-mars-R-linux-gtk-x86_64.tar.gz"
+    ECLIPSE_MD5_x86_64=6c2d45de8874b71a4eba19afe584acf6
+fi
+
 
 # D-Bus EMF model ---------------------------------------------------
 


### PR DESCRIPTION
Added easy-to-use configuration switch for choosing an Eclipse version. Just set ECLIPSE_DISTRO to either luna or mars. This might become a multi-case decision as soon as Neon is available.

Also introduced a list of possible mirrors for download (which currently has only two entries). Just set USE_ECLIPSE_MIRROR to one of the mirrors from the list.
