### PR TITLE
Add support for Windows 7/Cygwin64

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# See https://help.github.com/articles/dealing-with-line-endings/
+
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.c text
+*.h text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sln text eol=crlf
+
+# Preserve Unix line endings on those files (used inside the Linux VM)
+CONFIG text eol=lf
+script.sh text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+
+# EOF

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,13 +39,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
    # was defined above, but to make it unique a timestamp is added also.
    # Increase video RAM as well, it doesn't cost much and we will run
    # graphical desktops after all.
-   vmname = config.vm.hostname + "-" + `date +%Y%m%d%H%M`.to_s
-   vmname.chomp!      # Without this there is a newline character in the name :-o
+   # vmname = config.vm.hostname + "-" + `date +%Y%m%d%H%M`.to_s
+   # vmname.chomp!      # Without this there is a newline character in the name :-o
    config.vm.provider :virtualbox do |vb|
       # Don't boot with headless mode
       vb.gui = true
 
-      vb.customize [ "modifyvm", :id, "--name", vmname ]
+      # vb.customize [ "modifyvm", :id, "--name", vmname ]
       vb.customize [ "modifyvm", :id, "--memory", "1536" ]
       vb.customize [ "modifyvm", :id, "--vram", "128" ]
    end


### PR DESCRIPTION
A couple of small fixes to introduce support for Windows 7.

Tested on the following configuration:
- Host OS: MS Windows 7 64-bit
- Cygwin-64
- Vagrant 1.7.4
- VirtualBox 5.0.4

Please see https://genivi-oss.atlassian.net/wiki/x/JYBi for details.

NOTE: This PR is against the experimental branch "cpp_common_api", but should work on master as well.
