### PR TITLE
vmname: Use Ruby class to calculate timestamp

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,8 +41,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
    # was defined above, but to make it unique a timestamp is added also.
    # Increase video RAM as well, it doesn't cost much and we will run
    # graphical desktops after all.
-   vmname = config.vm.hostname + "-" + `date +%Y%m%d%H%M`.to_s
-   vmname.chomp!      # Without this there is a newline character in the name :-o
+   vmname = config.vm.hostname + "-" + Time.now.strftime("%Y%m%d%H%M")
    config.vm.provider :virtualbox do |vb|
       # Don't boot with headless mode
       vb.gui = true


### PR DESCRIPTION
The 'date' function that was used to calculate the timestamp
to be appended to vmname is not portable across Host Operating Systems -
at least it does not work on MS Windows - See https://github.com/gunnarx/franca_install_automation/issues/22

Use Ruby class 'Time' to achieve the same result.

Signed-off-by: Gianpaolo Macario gianpaolo_macario@mentor.com
